### PR TITLE
Add namespace option and expose via standard plugin interface

### DIFF
--- a/packages/mercurius-codegen/src/index.ts
+++ b/packages/mercurius-codegen/src/index.ts
@@ -4,10 +4,13 @@ import { GraphQLSchema } from 'graphql'
 
 import { TypeScriptPluginConfig } from '@graphql-codegen/typescript'
 import { TypeScriptResolversPluginConfig } from '@graphql-codegen/typescript-resolvers/config'
+import { MercuriusLoadersPlugin } from './mercuriusLoaders'
 
 import type { CodegenPlugin } from '@graphql-codegen/plugin-helpers'
 import type { Source } from '@graphql-tools/utils'
 import type { WatchOptions as ChokidarOptions } from 'chokidar'
+
+export { MercuriusLoadersPlugin as plugin }
 
 type MidCodegenPluginsConfig = TypeScriptPluginConfig &
   TypeScriptResolversPluginConfig
@@ -93,7 +96,6 @@ export async function generateCode(
     : null
   const { parse, printSchema } = await import('graphql')
   const { format, resolveConfig } = await import('prettier')
-  const { MercuriusLoadersPlugin } = await import('./mercuriusLoaders')
   const { loadFiles } = await import('@graphql-tools/load-files')
 
   const prettierConfig = resolveConfig(process.cwd()).then((config) => config)

--- a/packages/mercurius-codegen/src/mercuriusLoaders.ts
+++ b/packages/mercurius-codegen/src/mercuriusLoaders.ts
@@ -1,7 +1,11 @@
 import { CodegenPlugin } from '@graphql-codegen/plugin-helpers'
 
 export const MercuriusLoadersPlugin: CodegenPlugin = {
-  async plugin(schema) {
+  async plugin(schema, documents, config) {
+    const namespacedImportPrefix = config.namespacedImportName
+      ? `${config.namespacedImportName}.`
+      : ''
+
     const {
       GraphQLList,
       GraphQLNonNull,
@@ -79,8 +83,14 @@ export const MercuriusLoadersPlugin: CodegenPlugin = {
             if (isNullable) {
               fieldTypeToReturn = `Maybe<${fieldTypeToReturn}>`
             }
-            typeCode[key] = `LoaderResolver<${fieldTypeToReturn},${type.name},${
-              hasArgs ? `${type.name}${value.name}Args` : '{}'
+            typeCode[
+              key
+            ] = `LoaderResolver<${fieldTypeToReturn},${namespacedImportPrefix}${
+              type.name
+            },${
+              hasArgs
+                ? `${namespacedImportPrefix}${type.name}${value.name}Args`
+                : '{}'
             }, TContext>`
           } else {
             let fieldTypeToReturn = isArray
@@ -91,8 +101,14 @@ export const MercuriusLoadersPlugin: CodegenPlugin = {
               fieldTypeToReturn = `Maybe<${fieldTypeToReturn}>`
             }
 
-            typeCode[key] = `LoaderResolver<${fieldTypeToReturn},${type.name},${
-              hasArgs ? `${type.name}${value.name}Args` : '{}'
+            typeCode[
+              key
+            ] = `LoaderResolver<${fieldTypeToReturn},${namespacedImportPrefix}${
+              type.name
+            },${
+              hasArgs
+                ? `${namespacedImportPrefix}${type.name}${value.name}Args`
+                : '{}'
             }, TContext>`
           }
         })

--- a/packages/mercurius-codegen/tap-snapshots/test-index.test.ts-TAP.test.js
+++ b/packages/mercurius-codegen/tap-snapshots/test-index.test.ts-TAP.test.js
@@ -351,6 +351,31 @@ declare module 'mercurius' {
 
 `
 
+exports[`test/index.test.ts TAP generates code via plugin > pluginOutput 1`] = `
+
+    type Loader<TReturn, TObj, TParams, TContext> = (
+        queries: Array<{
+          obj: TObj;
+          params: TParams;
+        }>,
+        context: TContext & {
+          reply: FastifyReply;
+        }
+      ) => Promise<Array<DeepPartial<TReturn>>>;
+    type LoaderResolver<TReturn, TObj, TParams, TContext> = 
+    Loader<TReturn, TObj, TParams, TContext> | {
+        loader: Loader<TReturn, TObj, TParams, TContext>;
+        opts?:{
+            cache?:boolean
+        };
+    }
+    export interface Loaders<TContext = MercuriusContext & { reply: FastifyReply }> {
+      Human?: {
+        name?: LoaderResolver<Scalars["String"],TP_Types.Human,{}, TContext>;father?: LoaderResolver<Maybe<Human>,TP_Types.Human,{}, TContext>;hasSon?: LoaderResolver<Maybe<Scalars["Boolean"]>,TP_Types.Human,TP_Types.HumanhasSonArgs, TContext>;sons?: LoaderResolver<Array<Human>,TP_Types.Human,TP_Types.HumansonsArgs, TContext>;confirmedSonsNullable?: LoaderResolver<Maybe<Array<Human>>,TP_Types.Human,TP_Types.HumanconfirmedSonsNullableArgs, TContext>;confirmedSonsNonNullItems?: LoaderResolver<Array<Human>,TP_Types.Human,TP_Types.HumanconfirmedSonsNonNullItemsArgs, TContext>;sonNames?: LoaderResolver<Maybe<Array<Maybe<Scalars["String"]>>>,TP_Types.Human,{}, TContext>;nonNullssonNames?: LoaderResolver<Array<Scalars["String"]>,TP_Types.Human,{}, TContext>;
+      };
+        }
+`
+
 exports[`test/index.test.ts TAP gql helper > must match snapshot 1`] = `
 query A {
   hello

--- a/packages/mercurius-codegen/test/index.test.ts
+++ b/packages/mercurius-codegen/test/index.test.ts
@@ -15,6 +15,7 @@ import {
   generateCode,
   gql,
   writeGeneratedCode,
+  plugin,
 } from '../src/index'
 
 const { readFile } = fs.promises
@@ -383,6 +384,17 @@ tap.test('operations', async (t) => {
   t.assert(generatedCode2.includes('BDocument'))
 
   t.matchSnapshot(generatedCode2)
+})
+
+tap.test('generates code via plugin', async (t) => {
+  await app.ready()
+  const pluginOutput = await plugin.plugin(app.graphql.schema, [], {
+    namespacedImportName: 'TP_Types',
+  })
+
+  t.matchSnapshot(pluginOutput.toString(), 'pluginOutput')
+
+  t.done()
 })
 
 codegenMercurius(app, {


### PR DESCRIPTION
# What this does

1. Introduces the config option `namespacedImportName` - also seen in [typescript-resolvers](https://github.com/dotansimha/graphql-code-generator/blob/fd5843a7baea9d562d965bcd8badfdefb63959c4/packages/plugins/typescript/resolvers/src/index.ts#L36)
2. Expose the plugin via the standard plugin interface to allow standard codegen yaml config files to reference and use the plugin.

# Motivation
Adding this allows modular GQL type definition packages to be used in codegen.

This allows the generated resolvers to reference another pre-generated GQL types package without creating duplicate type generations.


Not sure on the contribution process for this but these changes come with basic tests. 

Please let me know if there are any questions or issues.