### PR TITLE
correct plugin import path

### DIFF
--- a/packages/mercurius-codegen/src/index.ts
+++ b/packages/mercurius-codegen/src/index.ts
@@ -6,7 +6,8 @@ import type { CodegenPluginsConfig } from './code'
 import { MercuriusLoadersPlugin } from './mercuriusLoaders'
 import { deferredPromise } from './utils'
 
-export { MercuriusLoadersPlugin as plugin }
+const { plugin } = MercuriusLoadersPlugin
+export { plugin }
 
 interface CodegenMercuriusOptions {
   /**

--- a/packages/mercurius-codegen/test/index.test.ts
+++ b/packages/mercurius-codegen/test/index.test.ts
@@ -106,7 +106,7 @@ let generatedCode: string
 test('generates code via plugin', async (t) => {
   t.plan(1)
   await app.ready()
-  const pluginOutput = await plugin.plugin(app.graphql.schema, [], {
+  const pluginOutput = await plugin(app.graphql.schema, [], {
     namespacedImportName: 'TP_Types',
   })
 


### PR DESCRIPTION
Noticed I miss-copied the patch.

The plugin function needs to be exported at the top level to be detected as a plugin by graphql-codegen.