### PR TITLE
Fix @graphql-codegen/typescript-resolvers import

### DIFF
--- a/packages/mercurius-codegen/src/code.ts
+++ b/packages/mercurius-codegen/src/code.ts
@@ -1,7 +1,7 @@
 import type {} from 'mercurius'
 import type { GraphQLSchema } from 'graphql'
 import type { TypeScriptPluginConfig } from '@graphql-codegen/typescript'
-import type { TypeScriptResolversPluginConfig } from '@graphql-codegen/typescript-resolvers/config'
+import type { TypeScriptResolversPluginConfig } from '@graphql-codegen/typescript-resolvers'
 import type { CodegenPlugin } from '@graphql-codegen/plugin-helpers'
 import type { Source } from '@graphql-tools/utils'
 import type { MercuriusLoadersPluginConfig } from './mercuriusLoaders'


### PR DESCRIPTION
`@graphql-codegen/typescript-resolvers` no longer exposes d.ts files in the package root since v2.7.0.

Import `TypeScriptResolversPluginConfig` directly from index to fix error. (it has been exported at least since v2.6.0)

```
node_modules/mercurius-codegen/dist/code.d.ts:3:54 - error TS2307: Cannot find module '@graphql-codegen/typescript-resolvers/config' or its corresponding type declarations.

3 import type { TypeScriptResolversPluginConfig } from '@graphql-codegen/typescript-resolvers/config';
                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```