### PR TITLE
Export `CodegenMercuriusOptions` interface

### DIFF
--- a/.changeset/sixty-houses-tap.md
+++ b/.changeset/sixty-houses-tap.md
@@ -1,0 +1,5 @@
+---
+'mercurius-codegen': patch
+---
+
+Export `CodegenMercuriusOptions` interface

--- a/examples/codegen-gql-files/src/index.ts
+++ b/examples/codegen-gql-files/src/index.ts
@@ -1,11 +1,19 @@
 import Fastify, { FastifyReply, FastifyRequest } from 'fastify'
 import { buildSchema } from 'graphql'
 import mercurius, { IResolvers, MercuriusLoaders } from 'mercurius'
-import { codegenMercurius, loadSchemaFiles } from 'mercurius-codegen'
+import { codegenMercurius, CodegenMercuriusOptions, loadSchemaFiles } from 'mercurius-codegen'
 
 export const app = Fastify({
   logger: true,
 })
+
+const codegenMercuriusOptions: CodegenMercuriusOptions = {
+  targetPath: './src/graphql/generated.ts',
+  operationsGlob: './src/graphql/operations/*.gql',
+  watchOptions: {
+    enabled: process.env.NODE_ENV === 'development',
+  },
+}
 
 const { schema } = loadSchemaFiles('src/graphql/schema/**/*.gql', {
   watchOptions: {
@@ -14,10 +22,7 @@ const { schema } = loadSchemaFiles('src/graphql/schema/**/*.gql', {
       app.graphql.replaceSchema(buildSchema(schema.join('\n')))
       app.graphql.defineResolvers(resolvers)
 
-      codegenMercurius(app, {
-        targetPath: './src/graphql/generated.ts',
-        operationsGlob: './src/graphql/operations/*.gql',
-      }).catch(console.error)
+      codegenMercurius(app, codegenMercuriusOptions).catch(console.error)
     },
   },
 })
@@ -124,12 +129,6 @@ app.register(mercurius, {
   subscription: true,
 })
 
-codegenMercurius(app, {
-  targetPath: './src/graphql/generated.ts',
-  operationsGlob: './src/graphql/operations/*.gql',
-  watchOptions: {
-    enabled: process.env.NODE_ENV === 'development',
-  },
-}).catch(console.error)
+codegenMercurius(app, codegenMercuriusOptions).catch(console.error)
 
 // app.listen(8000)

--- a/packages/mercurius-codegen/src/index.ts
+++ b/packages/mercurius-codegen/src/index.ts
@@ -11,7 +11,7 @@ export { plugin }
 
 export type {} from '@graphql-codegen/plugin-helpers'
 
-interface CodegenMercuriusOptions {
+export interface CodegenMercuriusOptions {
   /**
    * Specify the target path of the code generation.
    *


### PR DESCRIPTION
In a current project I am working on, it would be useful to have the `CodegenMercuriusOptions` interface exported. It's a relatively small change to the codebase and I believe there should be no problems with exporting this interface but correct me if I am wrong.

This specifically allows for extracting the options into a properly typed constant that can be then reused as is the case in the modified `codegen-gql-files` example.